### PR TITLE
fix: Codecov Token

### DIFF
--- a/test/action.yml
+++ b/test/action.yml
@@ -1,4 +1,8 @@
 name: Testing
+inputs:
+  codecov_token:
+    description: Codecov access token
+    required: true
 runs:
   using: 'composite'
   steps:
@@ -12,4 +16,4 @@ runs:
 
     - uses: codecov/codecov-action@v3
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        token: ${{ inputs.codecov_token }}


### PR DESCRIPTION
Require Codecov access token when running the testing action